### PR TITLE
Persist state between page loads

### DIFF
--- a/nuxt.config.js
+++ b/nuxt.config.js
@@ -45,6 +45,7 @@ module.exports = {
   ** Plugins to load before mounting the App
   */
   plugins: [
+    { src: '~/plugins/persist-state', ssr: false },
     { src: '~/plugins/resize-directive', ssr: false },
     { src: '~/plugins/vue-material', ssr: true },
     { src: '~/plugins/vue-portal', ssr: true },

--- a/package-lock.json
+++ b/package-lock.json
@@ -8346,6 +8346,11 @@
         "jsonify": "~0.0.0"
       }
     },
+    "shvl": {
+      "version": "1.3.1",
+      "resolved": "https://registry.npmjs.org/shvl/-/shvl-1.3.1.tgz",
+      "integrity": "sha512-+rRPP46hloYUAEImJcqprUgXu+05Ikqr4h4V+w5i2zJy37nAqtkQKufs3+3S2fDq6JNRrHMIQhB/Vaex+jgAAw=="
+    },
     "signal-exit": {
       "version": "3.0.2",
       "resolved": "https://registry.npmjs.org/signal-exit/-/signal-exit-3.0.2.tgz",
@@ -9826,6 +9831,15 @@
       "version": "3.0.1",
       "resolved": "https://registry.npmjs.org/vuex/-/vuex-3.0.1.tgz",
       "integrity": "sha512-wLoqz0B7DSZtgbWL1ShIBBCjv22GV5U+vcBFox658g6V0s4wZV9P4YjCNyoHSyIBpj1f29JBoNQIqD82cR4O3w=="
+    },
+    "vuex-persistedstate": {
+      "version": "2.5.4",
+      "resolved": "https://registry.npmjs.org/vuex-persistedstate/-/vuex-persistedstate-2.5.4.tgz",
+      "integrity": "sha512-XYJhKIwO+ZVlTaXyxKxnplrJ88Fnvk5aDw753bxzRw5/yMKLQ6lq9CDCBex2fwZaQcLibhtgJOxGCHjy9GLSlQ==",
+      "requires": {
+        "deepmerge": "^2.1.0",
+        "shvl": "^1.3.0"
+      }
     },
     "watchpack": {
       "version": "1.6.0",

--- a/package.json
+++ b/package.json
@@ -37,7 +37,8 @@
     "proj4": "^2.5.0",
     "query-string": "^6.2.0",
     "vue-material": "^1.0.0-beta-10.2",
-    "vue-resize-directive": "^1.1.4"
+    "vue-resize-directive": "^1.1.4",
+    "vuex-persistedstate": "^2.5.4"
   },
   "devDependencies": {
     "babel-eslint": "^8.2.1",

--- a/src/client/plugins/persist-state.js
+++ b/src/client/plugins/persist-state.js
@@ -1,0 +1,11 @@
+/**
+ * Persist and rehydrate app state between page loads
+ * @see https://github.com/robinvdvleuten/vuex-persistedstate#nuxtjs
+ */
+import createPersistedState from 'vuex-persistedstate'
+
+export default ({ store }) => {
+  createPersistedState({
+      key: 'app-state',
+  })(store)
+}


### PR DESCRIPTION
Ensure users never lose their data on page refresh.

@markomalis It would be nice if we could focus on the parcels on the map once the map is loaded.