### PR TITLE
Add trailing slashes to farm nav links

### DIFF
--- a/src/client/components/farm-nav/farm-nav.vue
+++ b/src/client/components/farm-nav/farm-nav.vue
@@ -3,17 +3,17 @@
     <md-tab
       id="parcels"
       md-label="Perceelinformatie"
-      to="/farm/parcels"
+      to="/farm/parcels/"
     />
     <md-tab
       id="measures"
       md-label="Maatregelen"
-      to="/farm/measures"
+      to="/farm/measures/"
     />
     <md-tab
       id="output"
       md-label="Output"
-      to="/farm/output"
+      to="/farm/output/"
     />
   </md-tabs>
 </template>


### PR DESCRIPTION
This way server-side redirects on Netlify and client-side navigation both use the same URLs. This ensures the correct active is always highlighted.

**[before](https://keukentafeltool.netlify.com/farm/measures/)**: "perceelinformatie" is highlighted when navigating to measures page server-side.

**[after](https://deploy-preview-19--keukentafeltool.netlify.com/farm/measures/)**: "maatregelen" is highlighted when navigating to measures page server-side.